### PR TITLE
Phoenix start command changed.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,4 +31,4 @@ RUN mix local.hex --force && \
 
 EXPOSE 4000
 
-CMD ["sh", "-c", "mix deps.get && mix phoenix.server"]
+CMD ["sh", "-c", "mix deps.get && mix phx.server"]


### PR DESCRIPTION
Simply changed from `mix phoenix.server` to `mix phx.server` since phoenix 1.3.